### PR TITLE
Add placeholder login/signup and dashboard views

### DIFF
--- a/src/main/java/com/team2/Residential_Maintenance_Management_System/HomeController.java
+++ b/src/main/java/com/team2/Residential_Maintenance_Management_System/HomeController.java
@@ -1,14 +1,17 @@
 package com.team2.Residential_Maintenance_Management_System;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
     @GetMapping("/")
-    public String index(Model model) {
-        model.addAttribute("msg", "Welcome to the Residential Maintenance Management System.");
-        return "index"; // looks for views/index.html
+    public String loginSignup() {
+        return "loginsignup";
+    }
+
+    @GetMapping("/dashboard")
+    public String dashboard() {
+        return "dashboard";
     }
 }

--- a/src/main/resources/views/dashboard.html
+++ b/src/main/resources/views/dashboard.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard - Residential Maintenance Management System</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+
+        .container {
+            text-align: center;
+            padding: 3rem 2rem;
+            background: rgba(15, 23, 42, 0.85);
+            border-radius: 20px;
+            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+            max-width: 560px;
+            width: 100%;
+        }
+
+        h1 {
+            margin-bottom: 1rem;
+            font-size: 2.5rem;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 0 auto 2.5rem;
+            max-width: 440px;
+            line-height: 1.6;
+            color: rgba(226, 232, 240, 0.85);
+        }
+
+        .button {
+            display: inline-block;
+            padding: 0.85rem 1.75rem;
+            border-radius: 999px;
+            font-size: 1rem;
+            font-weight: 600;
+            text-decoration: none;
+            color: #0f172a;
+            background: #38bdf8;
+            transition: background 0.3s ease, transform 0.2s ease;
+        }
+
+        .button:hover {
+            background: #7dd3fc;
+            transform: translateY(-2px);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Dashboard</h1>
+        <p>This is a placeholder for the Residential Maintenance Management System dashboard. Functionality will be added in a future update.</p>
+        <a class="button" href="/">Return to Login / Sign Up</a>
+    </div>
+</body>
+</html>

--- a/src/main/resources/views/loginsignup.html
+++ b/src/main/resources/views/loginsignup.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login / Sign Up - Residential Maintenance Management System</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #2b5876, #4e4376);
+            color: #f5f5f5;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 16px;
+            backdrop-filter: blur(10px);
+            padding: 3rem 2.5rem;
+            max-width: 420px;
+            width: 100%;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+            text-align: center;
+        }
+
+        h1 {
+            margin-bottom: 0.75rem;
+            font-size: 2rem;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 0 0 2.5rem;
+            color: rgba(245, 245, 245, 0.85);
+            line-height: 1.5;
+        }
+
+        .actions {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .button {
+            display: inline-block;
+            padding: 0.85rem 1rem;
+            border-radius: 999px;
+            font-size: 1rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition: background 0.3s ease, transform 0.2s ease;
+        }
+
+        .button.primary {
+            background: #00c6ff;
+            color: #0f172a;
+        }
+
+        .button.secondary {
+            background: transparent;
+            color: #f5f5f5;
+            border: 2px solid rgba(245, 245, 245, 0.8);
+        }
+
+        .button:hover {
+            transform: translateY(-2px);
+        }
+
+        .button.primary:hover {
+            background: #7cf3ff;
+        }
+
+        .button.secondary:hover {
+            background: rgba(255, 255, 255, 0.12);
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Welcome Back!</h1>
+        <p>Select an option below to log in to your account or create a new one. You will be redirected to the dashboard placeholder for now.</p>
+        <div class="actions">
+            <a class="button primary" href="/dashboard">Log In</a>
+            <a class="button secondary" href="/dashboard">Sign Up</a>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a login/sign up view to act as the new landing page and link to the dashboard placeholder
- introduce a dashboard view with a return link back to the login/sign up page
- update the home controller to serve the new pages

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df7ba05478832bb8db3d4f20e858cf