### PR TITLE
Add IntelliJ run configuration for JavaFX

### DIFF
--- a/.idea/runConfigurations/MainApplication_with_JavaFX.xml
+++ b/.idea/runConfigurations/MainApplication_with_JavaFX.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MainApplication (JavaFX)" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.maintenance.MainApplication" />
+    <module name="Residential-Maintenance-Management-System" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="VM_PARAMETERS" value="--module-path $MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.1 --add-modules javafx.controls,javafx.fxml" />
+    <shortenClasspath name="NONE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Residential Maintenance Management System
+
+## Running the JavaFX application from IntelliJ IDEA
+
+If you receive the error `JavaFX runtime components are missing` when running `com.maintenance.MainApplication`, the IDE is launching the app without the required JavaFX modules on the module path.
+
+To fix this, use the bundled run configuration that adds the JavaFX modules automatically:
+
+1. In IntelliJ IDEA open the *Run* configuration chooser and pick **MainApplication (JavaFX)**.
+2. This configuration passes the correct `--module-path` and `--add-modules` flags so that the JavaFX runtime is available at launch.
+3. Press *Run* (or *Debug*) to start the application.
+
+If you prefer to configure the settings manually, edit the run configuration for `MainApplication` and add the following VM options:
+
+```
+--module-path $MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.1:$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.1 --add-modules javafx.controls,javafx.fxml
+```
+
+`$MAVEN_REPOSITORY$` is an IntelliJ macro that expands to your local Maven repository (for example `~/.m2/repository`). The new run configuration stored in `.idea/runConfigurations/MainApplication_with_JavaFX.xml` already includes these settings so you can run the UI without further changes.


### PR DESCRIPTION
- add an IntelliJ IDEA run configuration that passes the required JavaFX module-path VM options
- document how to launch MainApplication using the provided configuration or by setting the VM options manually