### PR TITLE
Allow tenants to edit maintenance tickets

### DIFF
--- a/src/main/java/com/maintenance/dao/MaintenanceRequestDAO.java
+++ b/src/main/java/com/maintenance/dao/MaintenanceRequestDAO.java
@@ -39,20 +39,23 @@ public class MaintenanceRequestDAO {
     }
 
     public boolean updateRequest(MaintenanceRequest request) {
-        String sql = "UPDATE maintenance_requests SET status = ?, last_updated = ?, " +
-                "assigned_staff_id = ?, scheduled_date = ?, completion_date = ?, " +
-                "resolution_notes = ? WHERE request_id = ?";
+        String sql = "UPDATE maintenance_requests SET description = ?, category = ?, priority = ?, " +
+                "status = ?, last_updated = ?, assigned_staff_id = ?, scheduled_date = ?, " +
+                "completion_date = ?, resolution_notes = ? WHERE request_id = ?";
 
         try (PreparedStatement pstmt = dbManager.getConnection().prepareStatement(sql)) {
-            pstmt.setString(1, request.getStatus().name());
-            pstmt.setTimestamp(2, Timestamp.valueOf(request.getLastUpdated()));
-            pstmt.setString(3, request.getAssignedStaffId());
-            pstmt.setTimestamp(4, request.getScheduledDate() != null ?
+            pstmt.setString(1, request.getDescription());
+            pstmt.setString(2, request.getCategory().name());
+            pstmt.setString(3, request.getPriority().name());
+            pstmt.setString(4, request.getStatus().name());
+            pstmt.setTimestamp(5, Timestamp.valueOf(request.getLastUpdated()));
+            pstmt.setString(6, request.getAssignedStaffId());
+            pstmt.setTimestamp(7, request.getScheduledDate() != null ?
                     Timestamp.valueOf(request.getScheduledDate()) : null);
-            pstmt.setTimestamp(5, request.getCompletionDate() != null ?
+            pstmt.setTimestamp(8, request.getCompletionDate() != null ?
                     Timestamp.valueOf(request.getCompletionDate()) : null);
-            pstmt.setString(6, request.getResolutionNotes());
-            pstmt.setString(7, request.getRequestId());
+            pstmt.setString(9, request.getResolutionNotes());
+            pstmt.setString(10, request.getRequestId());
 
             pstmt.executeUpdate();
             return true;

--- a/src/main/java/com/maintenance/database/DatabaseManager.java
+++ b/src/main/java/com/maintenance/database/DatabaseManager.java
@@ -66,13 +66,22 @@ public class DatabaseManager {
     }
 
     public boolean updateRequest(com.maintenance.models.MaintenanceRequest request) {
-        String sql = "UPDATE maintenance_requests SET status = ?, last_updated = ?, " +
-                "assigned_staff_id = ? WHERE request_id = ?";
+        String sql = "UPDATE maintenance_requests SET description = ?, category = ?, priority = ?, " +
+                "status = ?, last_updated = ?, assigned_staff_id = ?, scheduled_date = ?, completion_date = ?, " +
+                "resolution_notes = ? WHERE request_id = ?";
         try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
-            pstmt.setString(1, request.getStatus().name());
-            pstmt.setTimestamp(2, Timestamp.valueOf(request.getLastUpdated()));
-            pstmt.setString(3, request.getAssignedStaffId());
-            pstmt.setString(4, request.getRequestId());
+            pstmt.setString(1, request.getDescription());
+            pstmt.setString(2, request.getCategory().name());
+            pstmt.setString(3, request.getPriority().name());
+            pstmt.setString(4, request.getStatus().name());
+            pstmt.setTimestamp(5, Timestamp.valueOf(request.getLastUpdated()));
+            pstmt.setString(6, request.getAssignedStaffId());
+            pstmt.setTimestamp(7, request.getScheduledDate() != null ?
+                    Timestamp.valueOf(request.getScheduledDate()) : null);
+            pstmt.setTimestamp(8, request.getCompletionDate() != null ?
+                    Timestamp.valueOf(request.getCompletionDate()) : null);
+            pstmt.setString(9, request.getResolutionNotes());
+            pstmt.setString(10, request.getRequestId());
             pstmt.executeUpdate();
             return true;
         } catch (SQLException e) {


### PR DESCRIPTION
- add an Actions column with edit buttons to the tenant request table so tickets can be modified after submission
- provide an edit dialog that lets tenants update category, description, priority, and status with default priority helpers
- extend request persistence updates to include description, category, priority, and status fields so edits are saved
