### PR TITLE
Allow tenants to edit maintenance tickets

### DIFF
--- a/src/main/java/com/maintenance/dao/MaintenanceRequestDAO.java
+++ b/src/main/java/com/maintenance/dao/MaintenanceRequestDAO.java
@@ -39,20 +39,23 @@ public class MaintenanceRequestDAO {
     }
 
     public boolean updateRequest(MaintenanceRequest request) {
-        String sql = "UPDATE maintenance_requests SET status = ?, last_updated = ?, " +
-                "assigned_staff_id = ?, scheduled_date = ?, completion_date = ?, " +
-                "resolution_notes = ? WHERE request_id = ?";
+        String sql = "UPDATE maintenance_requests SET description = ?, category = ?, priority = ?, " +
+                "status = ?, last_updated = ?, assigned_staff_id = ?, scheduled_date = ?, " +
+                "completion_date = ?, resolution_notes = ? WHERE request_id = ?";
 
         try (PreparedStatement pstmt = dbManager.getConnection().prepareStatement(sql)) {
-            pstmt.setString(1, request.getStatus().name());
-            pstmt.setTimestamp(2, Timestamp.valueOf(request.getLastUpdated()));
-            pstmt.setString(3, request.getAssignedStaffId());
-            pstmt.setTimestamp(4, request.getScheduledDate() != null ?
+            pstmt.setString(1, request.getDescription());
+            pstmt.setString(2, request.getCategory().name());
+            pstmt.setString(3, request.getPriority().name());
+            pstmt.setString(4, request.getStatus().name());
+            pstmt.setTimestamp(5, Timestamp.valueOf(request.getLastUpdated()));
+            pstmt.setString(6, request.getAssignedStaffId());
+            pstmt.setTimestamp(7, request.getScheduledDate() != null ?
                     Timestamp.valueOf(request.getScheduledDate()) : null);
-            pstmt.setTimestamp(5, request.getCompletionDate() != null ?
+            pstmt.setTimestamp(8, request.getCompletionDate() != null ?
                     Timestamp.valueOf(request.getCompletionDate()) : null);
-            pstmt.setString(6, request.getResolutionNotes());
-            pstmt.setString(7, request.getRequestId());
+            pstmt.setString(9, request.getResolutionNotes());
+            pstmt.setString(10, request.getRequestId());
 
             pstmt.executeUpdate();
             return true;

--- a/src/main/java/com/maintenance/database/DatabaseManager.java
+++ b/src/main/java/com/maintenance/database/DatabaseManager.java
@@ -66,13 +66,22 @@ public class DatabaseManager {
     }
 
     public boolean updateRequest(com.maintenance.models.MaintenanceRequest request) {
-        String sql = "UPDATE maintenance_requests SET status = ?, last_updated = ?, " +
-                "assigned_staff_id = ? WHERE request_id = ?";
+        String sql = "UPDATE maintenance_requests SET description = ?, category = ?, priority = ?, " +
+                "status = ?, last_updated = ?, assigned_staff_id = ?, scheduled_date = ?, completion_date = ?, " +
+                "resolution_notes = ? WHERE request_id = ?";
         try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
-            pstmt.setString(1, request.getStatus().name());
-            pstmt.setTimestamp(2, Timestamp.valueOf(request.getLastUpdated()));
-            pstmt.setString(3, request.getAssignedStaffId());
-            pstmt.setString(4, request.getRequestId());
+            pstmt.setString(1, request.getDescription());
+            pstmt.setString(2, request.getCategory().name());
+            pstmt.setString(3, request.getPriority().name());
+            pstmt.setString(4, request.getStatus().name());
+            pstmt.setTimestamp(5, Timestamp.valueOf(request.getLastUpdated()));
+            pstmt.setString(6, request.getAssignedStaffId());
+            pstmt.setTimestamp(7, request.getScheduledDate() != null ?
+                    Timestamp.valueOf(request.getScheduledDate()) : null);
+            pstmt.setTimestamp(8, request.getCompletionDate() != null ?
+                    Timestamp.valueOf(request.getCompletionDate()) : null);
+            pstmt.setString(9, request.getResolutionNotes());
+            pstmt.setString(10, request.getRequestId());
             pstmt.executeUpdate();
             return true;
         } catch (SQLException e) {

--- a/src/main/java/com/maintenance/enums/RequestStatus.java
+++ b/src/main/java/com/maintenance/enums/RequestStatus.java
@@ -7,6 +7,7 @@ public enum RequestStatus {
     IN_PROGRESS("In Progress", "#FF9800", "⚙️"),
     ON_HOLD("On Hold", "#9E9E9E", "⏸️"),
     COMPLETED("Completed", "#4CAF50", "✅"),
+    REOPENED("Reopened", "#FF7043", "🔁"),
     CLOSED("Closed", "#607D8B", "🔒"),
     CANCELLED("Cancelled", "#F44336", "❌");
 
@@ -34,7 +35,7 @@ public enum RequestStatus {
 
     public boolean isActive() {
         return this == SUBMITTED || this == ACKNOWLEDGED ||
-                this == ASSIGNED || this == IN_PROGRESS;
+                this == ASSIGNED || this == IN_PROGRESS || this == REOPENED;
     }
 
     public boolean isTerminal() {

--- a/src/main/java/com/maintenance/ui/controllers/TenantDashboardController.java
+++ b/src/main/java/com/maintenance/ui/controllers/TenantDashboardController.java
@@ -3,15 +3,18 @@ package com.maintenance.ui.controllers;
 import com.maintenance.dao.MaintenanceRequestDAO;
 import com.maintenance.enums.CategoryType;
 import com.maintenance.enums.PriorityLevel;
+import com.maintenance.enums.RequestStatus;
 import com.maintenance.models.MaintenanceRequest;
 import com.maintenance.models.Tenant;
 import com.maintenance.service.AuthenticationService;
 import com.maintenance.service.TicketingSystem;
 import com.maintenance.ui.views.ViewFactory;
+import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.*;
@@ -19,6 +22,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.stage.Stage;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class TenantDashboardController {
@@ -163,7 +167,8 @@ public class TenantDashboardController {
 
         long pending = requests.stream()
                 .filter(r -> r.getStatus().name().contains("SUBMITTED") ||
-                        r.getStatus().name().contains("IN_PROGRESS"))
+                        r.getStatus().name().contains("IN_PROGRESS") ||
+                        r.getStatus() == RequestStatus.REOPENED)
                 .count();
 
         long completed = requests.stream()
@@ -247,7 +252,40 @@ public class TenantDashboardController {
         );
         dateCol.setPrefWidth(100);
 
-        requestTable.getColumns().addAll(idCol, categoryCol, descCol, priorityCol, statusCol, dateCol);
+        TableColumn<MaintenanceRequest, Void> actionCol = new TableColumn<>("Actions");
+        actionCol.setPrefWidth(120);
+        actionCol.setCellFactory(col -> new TableCell<>() {
+            private final Button editButton = createEditButton();
+
+            private Button createEditButton() {
+                Button button = new Button("Edit");
+                button.setStyle("-fx-background-color: #4caf50; -fx-text-fill: white; " +
+                        "-fx-padding: 6 14; -fx-background-radius: 5; -fx-cursor: hand;");
+                button.setOnAction(event -> {
+                    MaintenanceRequest request = getTableView().getItems().get(getIndex());
+                    if (request != null) {
+                        showEditRequestDialog(request);
+                    }
+                });
+                return button;
+            }
+
+            @Override
+            protected void updateItem(Void item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty) {
+                    setGraphic(null);
+                } else {
+                    MaintenanceRequest request = getTableView().getItems().get(getIndex());
+                    editButton.setDisable(!canTenantEdit(request));
+                    setGraphic(editButton);
+                    setAlignment(Pos.CENTER);
+                }
+            }
+        });
+        actionCol.setSortable(false);
+
+        requestTable.getColumns().addAll(idCol, categoryCol, descCol, priorityCol, statusCol, dateCol, actionCol);
 
         loadRequests();
 
@@ -260,6 +298,148 @@ public class TenantDashboardController {
         ObservableList<MaintenanceRequest> requests =
                 FXCollections.observableArrayList(requestDAO.getRequestsByTenant(tenant.getUserId()));
         requestTable.setItems(requests);
+    }
+
+    private void showEditRequestDialog(MaintenanceRequest request) {
+        Dialog<MaintenanceRequest> dialog = new Dialog<>();
+        dialog.setTitle("Edit Maintenance Request");
+        dialog.setHeaderText("Update your ticket details");
+
+        ButtonType saveButtonType = new ButtonType("Save Changes", ButtonBar.ButtonData.OK_DONE);
+        dialog.getDialogPane().getButtonTypes().addAll(saveButtonType, ButtonType.CANCEL);
+
+        GridPane grid = new GridPane();
+        grid.setHgap(10);
+        grid.setVgap(10);
+        grid.setPadding(new Insets(20));
+
+        ComboBox<CategoryType> categoryBox = new ComboBox<>();
+        categoryBox.getItems().addAll(CategoryType.values());
+        categoryBox.setValue(request.getCategory());
+
+        TextArea descArea = new TextArea();
+        descArea.setPromptText("Describe the issue...");
+        descArea.setPrefRowCount(4);
+        descArea.setText(request.getDescription());
+
+        ComboBox<PriorityLevel> priorityBox = new ComboBox<>();
+        priorityBox.getItems().addAll(PriorityLevel.values());
+        priorityBox.setValue(request.getPriority());
+
+        Button defaultPriorityBtn = new Button("Use Default Priority");
+        defaultPriorityBtn.setOnAction(e -> {
+            CategoryType selectedCategory = categoryBox.getValue();
+            if (selectedCategory != null) {
+                priorityBox.setValue(getDefaultPriorityForCategory(selectedCategory));
+            }
+        });
+
+        categoryBox.valueProperty().addListener((obs, oldVal, newVal) -> {
+            if (newVal != null) {
+                priorityBox.setValue(getDefaultPriorityForCategory(newVal));
+            }
+        });
+
+        ComboBox<RequestStatus> statusBox = new ComboBox<>();
+        ObservableList<RequestStatus> allowedStatuses = FXCollections.observableArrayList();
+        RequestStatus currentStatus = request.getStatus();
+        if (currentStatus != null) {
+            allowedStatuses.add(currentStatus);
+            if (currentStatus == RequestStatus.SUBMITTED) {
+                allowedStatuses.add(RequestStatus.CLOSED);
+            } else if (currentStatus == RequestStatus.CLOSED) {
+                allowedStatuses.add(RequestStatus.REOPENED);
+            } else if (currentStatus == RequestStatus.REOPENED) {
+                allowedStatuses.add(RequestStatus.CLOSED);
+            }
+        }
+        statusBox.setItems(allowedStatuses);
+        statusBox.setValue(currentStatus);
+        statusBox.setDisable(allowedStatuses.size() <= 1);
+
+        grid.add(new Label("Category:"), 0, 0);
+        grid.add(categoryBox, 1, 0);
+        grid.add(new Label("Description:"), 0, 1);
+        grid.add(descArea, 1, 1);
+        grid.add(new Label("Priority:"), 0, 2);
+        HBox priorityContainer = new HBox(10, priorityBox, defaultPriorityBtn);
+        grid.add(priorityContainer, 1, 2);
+        grid.add(new Label("Status:"), 0, 3);
+        grid.add(statusBox, 1, 3);
+
+        Node saveButton = dialog.getDialogPane().lookupButton(saveButtonType);
+        saveButton.disableProperty().bind(Bindings.createBooleanBinding(
+                () -> categoryBox.getValue() == null ||
+                        priorityBox.getValue() == null ||
+                        statusBox.getValue() == null ||
+                        descArea.getText().trim().isEmpty(),
+                categoryBox.valueProperty(),
+                priorityBox.valueProperty(),
+                statusBox.valueProperty(),
+                descArea.textProperty()
+        ));
+
+        dialog.getDialogPane().setContent(grid);
+
+        dialog.setResultConverter(dialogButton -> {
+            if (dialogButton == saveButtonType) {
+                request.setCategory(categoryBox.getValue());
+                request.setDescription(descArea.getText().trim());
+                request.setPriority(priorityBox.getValue());
+                RequestStatus newStatus = statusBox.getValue();
+                request.setStatus(newStatus);
+                request.setLastUpdated(LocalDateTime.now());
+
+                if (newStatus == RequestStatus.COMPLETED && request.getCompletionDate() == null) {
+                    request.setCompletionDate(LocalDateTime.now());
+                } else if (newStatus != RequestStatus.COMPLETED) {
+                    request.setCompletionDate(null);
+                }
+                return request;
+            }
+            return null;
+        });
+
+        dialog.showAndWait().ifPresent(updatedRequest -> {
+            if (requestDAO.updateRequest(updatedRequest)) {
+                Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                alert.setTitle("Request Updated");
+                alert.setHeaderText("Changes Saved");
+                alert.setContentText("Your maintenance request has been updated successfully.");
+                alert.showAndWait();
+                loadRequests();
+            } else {
+                Alert alert = new Alert(Alert.AlertType.ERROR);
+                alert.setTitle("Update Failed");
+                alert.setHeaderText("Unable to Save Changes");
+                alert.setContentText("Please try again later or contact support.");
+                alert.showAndWait();
+            }
+        });
+    }
+
+    private PriorityLevel getDefaultPriorityForCategory(CategoryType category) {
+        switch (category) {
+            case EMERGENCY:
+                return PriorityLevel.EMERGENCY;
+            case ELECTRICAL:
+            case SAFETY_SECURITY:
+                return PriorityLevel.URGENT;
+            case PLUMBING:
+            case HVAC:
+                return PriorityLevel.HIGH;
+            case APPLIANCE:
+                return PriorityLevel.MEDIUM;
+            default:
+                return PriorityLevel.LOW;
+        }
+    }
+
+    private boolean canTenantEdit(MaintenanceRequest request) {
+        if (request == null || request.getStatus() == null) {
+            return false;
+        }
+        return request.getStatus() != RequestStatus.CANCELLED;
     }
 
     private void showNewRequestDialog() {


### PR DESCRIPTION
- add an Actions column with edit buttons to the tenant request table so tickets can be modified after submission
- provide an edit dialog that lets tenants update category, description, priority, and status with default priority helpers
- extend request persistence updates to include description, category, priority, and status fields so edits are saved
- introduce a REOPENED status and limit tenant edits to closing submitted tickets or reopening closed ones so status changes follow tenant rules